### PR TITLE
E_USER_WARNING error when png/blur enabled without required functions…

### DIFF
--- a/captcha.php
+++ b/captcha.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Script para la generación de CAPTCHAS
+ * Script para la generaciÃ³n de CAPTCHAS
  *
  * @author  Jose Rodriguez <josecl@gmail.com>
  * @license GPLv3
@@ -212,8 +212,13 @@ class SimpleCaptcha {
             $this->WriteLine();
         }
         $this->WaveImage();
-        if ($this->blur && function_exists('imagefilter')) {
-            imagefilter($this->im, IMG_FILTER_GAUSSIAN_BLUR);
+        
+        if ($this->blur) {
+            if(!function_exists('imagefilter')){
+                trigger_error('blur is enabled, but imagefilter is not available. will not be able to blur image. fix your installation or disable blur!',E_USER_WARNING);
+            } else {
+                imagefilter($this->im, IMG_FILTER_GAUSSIAN_BLUR);
+            }
         }
         $this->ReduceImage();
 
@@ -476,7 +481,7 @@ class SimpleCaptcha {
      * Reduce the image to the final size
      */
     protected function ReduceImage() {
-        // Reduzco el tamaño de la imagen
+        // Reduzco el tamaÃ±o de la imagen
         $imResampled = imagecreatetruecolor($this->width, $this->height);
         imagecopyresampled($imResampled, $this->im,
             0, 0, 0, 0,
@@ -498,12 +503,20 @@ class SimpleCaptcha {
      * File generation
      */
     protected function WriteImage() {
-        if ($this->imageFormat == 'png' && function_exists('imagepng')) {
+        if($this->imageFormat=='png'){
+            if(!function_exists('imagepng')){
+                trigger_error('imageFormat is set to png, but imagepng is not available. fix your installation or change to jpg format! will fallback to jpg..',E_USER_WARNING);
+                header("Content-type: image/jpeg");
+                imagejpeg($this->im, null, 80);
+                return;
+            }
             header("Content-type: image/png");
             imagepng($this->im);
+            return;
         } else {
             header("Content-type: image/jpeg");
             imagejpeg($this->im, null, 80);
+            return;
         }
     }
 


### PR DESCRIPTION
… available

generate error logs when blur is enabled but the required function imagefilter is not available.
likewise if imageFormat="png" but imagepng is not available. 

in development environments, this should catch the developer's attention immediately (display_errors=1 and broken images), whilst on production servers, should at generate some error logs so sysadmins can notice :p

IMO, it's even debatable whether or not image generation should continue, with reduced security, if blur is enabled but imagefilter is not, or if we should just outright cast an exception, because... reduced security! / presumably easier captcha