### PR TITLE
fix: font no found warning

### DIFF
--- a/captcha.php
+++ b/captcha.php
@@ -427,7 +427,7 @@ class SimpleCaptcha {
         }
 
         // Full path of font file
-        $fontfile = $this->resourcesPath.'/fonts/'.$fontcfg['font'];
+        $fontfile = __DIR__ . DIRECTORY_SEPARATOR . $this->resourcesPath.'/fonts/'.$fontcfg['font'];
 
 
         /** Increase font-size for shortest words: 9% for each glyp missing */


### PR DESCRIPTION
# Fix
- Image couldn't display with font not found warning
`PHP Warning:  imagettftext(): Could not find/open font in captcha.php on line 430`